### PR TITLE
Fixed incorrect version reference.

### DIFF
--- a/source/noveris.build/noveris.build.psm1
+++ b/source/noveris.build/noveris.build.psm1
@@ -2,7 +2,7 @@
 #>
 
 #Requires -Modules @{"ModuleName"="Noveris.Logger";"RequiredVersion"="0.6.1"}
-#Requires -Modules @{"ModuleName"="Noveris.Version";"RequiredVersion"="0.5.0"}
+#Requires -Modules @{"ModuleName"="Noveris.Version";"RequiredVersion"="0.5.1"}
 #Requires -Modules @{"ModuleName"="Noveris.GitHubApi";"RequiredVersion"="0.1.2"}
 
 ########


### PR DESCRIPTION
Fixed incorrect noveris.version reference in noveris.build.psm1.